### PR TITLE
scalajs 1.x support

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.2
+sbt.version = 1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,22 @@
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.9")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+val sjs1x = "1."
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.1.0")
+
+resolvers += Resolver.bintrayRepo("oyvindberg", "converter")
+
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M9")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-git"              % "0.9.3")
-resolvers += Resolver.bintrayRepo("oyvindberg", "ScalablyTyped")
-addSbtPlugin("org.scalablytyped" % "sbt-scalablytyped" % "202004090420")
+
+if(scalaJSVersion startsWith sjs1x) {
+  addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
+  addSbtPlugin("org.scalablytyped.converter" % "sbt-converter" % "1.0.0-beta15")
+} else {
+  addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler-sjs06" % "0.18.0")
+  addSbtPlugin("org.scalablytyped.converter" % "sbt-converter06" % "1.0.0-beta15")
+}
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.9.7")

--- a/slinky/src/main/scala/com/olegpy/shironeko/DirectConnector.scala
+++ b/slinky/src/main/scala/com/olegpy/shironeko/DirectConnector.scala
@@ -27,7 +27,7 @@ class DirectConnector[F[_], Algebra] { self =>
     type State
     type Props
 
-    protected def getClassName = self.getClass.getSimpleName
+    protected def getClassName: String = self.getClass.getSimpleName
 
     private[this] object Impl extends Underlying.Container {
       override type State = self.State

--- a/slinky/src/main/scala/com/olegpy/shironeko/TaglessConnector.scala
+++ b/slinky/src/main/scala/com/olegpy/shironeko/TaglessConnector.scala
@@ -64,7 +64,7 @@ class TaglessConnector[Algebra[_[_]]] { conn =>
     type State[F[_]]
     type Props
 
-    protected def getClassName = this.getClass.getSimpleName
+    protected def getClassName: String = this.getClass.getSimpleName
 
     lazy val fcName = new FunctionalComponentName(getClassName)
 
@@ -122,16 +122,16 @@ class TaglessConnector[Algebra[_[_]]] { conn =>
     type State
     type Props
 
-    protected def getClassName = self.getClass.getSimpleName
+    protected def getClassName: String = self.getClass.getSimpleName
 
     private[this] object underlying extends ContainerF {
       type State[F[_]] = self.State
       type Props = self.Props
 
-      override protected def getClassName = self.getClassName
+      override protected def getClassName: String = self.getClassName
 
-      def subscribe[F[_]: Subscribe] = self.subscribe[F]
-      def render[F[_]: Render](state: State[F], props: Props) =
+      def subscribe[F[_]: Subscribe]: fs2.Stream[F, State[F]] = self.subscribe[F]
+      def render[F[_]: Render](state: State[F], props: Props): ReactElement =
         self.render[F](state, props)
     }
 

--- a/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/App.scala
+++ b/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/App.scala
@@ -1,10 +1,13 @@
 package com.olegpy.shironeko.todomvc
 
-import com.olegpy.shironeko.todomvc.components._
 import cats.implicits._
-import slinky.web.html._
+import com.olegpy.shironeko.todomvc.components._
 import monix.eval.Task
-import slinky.core.facade.{Fragment, ReactElement}
+import org.scalajs.dom.Event
+import slinky.core.SyntheticEvent
+import slinky.core.facade.Fragment
+import slinky.core.facade.ReactElement
+import slinky.web.html._
 
 
 object TodoApp extends Connector.Container {
@@ -32,9 +35,7 @@ object TodoApp extends Connector.Container {
               className := "toggle-all",
               `type` := "checkbox",
               checked := allCompleted,
-              onChange := { e =>
-                exec(TodoActions().setAllStatus(e.target.checked))
-              }
+              onChange := { handleCheckboxChange(_) }
             ),
             label(
               htmlFor := "toggle-all",
@@ -56,5 +57,11 @@ object TodoApp extends Connector.Container {
       ),
       TodoInfo()
     )
+  }
+
+
+
+  private[this] def handleCheckboxChange(e: SyntheticEvent[input.tag.RefType, Event]): Unit = {
+    exec(TodoActions().setAllStatus(e.target.checked))
   }
 }

--- a/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/Main.scala
+++ b/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/Main.scala
@@ -1,16 +1,19 @@
 package com.olegpy.shironeko.todomvc
 
-import scala.scalajs.js
-import scala.scalajs.js.annotation.{JSExportTopLevel, JSImport}
-import scala.scalajs.LinkingInfo
-
 import cats.effect.ExitCode
 import cats.implicits._
 import com.olegpy.shironeko.StoreDSL
-import monix.eval.{Task, TaskApp}
-import slinky.web.ReactDOM
-import slinky.hot
+import monix.eval.Task
+import monix.eval.TaskApp
 import org.scalajs.dom
+import org.scalajs.dom.raw.Element
+import slinky.hot
+import slinky.web.ReactDOM
+
+import scala.scalajs.LinkingInfo
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSExportTopLevel
+import scala.scalajs.js.annotation.JSImport
 
 @JSImport("todomvc-app-css/index.css", JSImport.Default)
 @js.native
@@ -32,7 +35,7 @@ object Main extends TaskApp {
       } >> Task.never[ExitCode]
   }
 
-  val getRoot = Task {
+  val getRoot: Task[Element] = Task {
     Option(dom.document.getElementById("root")).getOrElse {
       val elem = dom.document.createElement("div")
       elem.id = "root"
@@ -41,7 +44,7 @@ object Main extends TaskApp {
     }
   }
 
-  val initHotLoading = Task {
+  val initHotLoading: Task[Unit] = Task {
     if (LinkingInfo.developmentMode) {
       hot.initialize()
     }

--- a/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/Routes.scala
+++ b/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/Routes.scala
@@ -1,37 +1,41 @@
 package com.olegpy.shironeko.todomvc
 
-import scala.scalajs.js
-
 import com.olegpy.shironeko.util.shift
 import slinky.core.ExternalComponent
 import slinky.core.annotations.react
-import typings.reactLib.ScalableSlinky._
-import typings.reactDashRouterDashDomLib.reactDashRouterDashDomLibComponents.{Link => JSLink, _}
-import typings.reactDashRouterLib.reactDashRouterMod.RouteProps
+import slinky.core.facade.ReactElement
+import typings.reactRouter.mod.RouteProps
+import typings.reactRouterDom.components.HashRouter
+import typings.reactRouterDom.components.Route
+import typings.reactRouterDom.components.{Link => JSLink}
+
+import scala.scalajs.js
 
 object Routes {
-  def apply() = shift {
-    HashRouter.noprops(
-      Route[RouteProps].props(RouteProps(
+
+  def apply(): ReactElement = shift {
+    HashRouter(
+      Route(RouteProps(
         exact = true,
         path = "/",
         render = _ => TodoApp(Filter.All)
       )),
-      Route[RouteProps].props(RouteProps(
+      Route(RouteProps(
         path = "/active",
         render = _ => TodoApp(Filter.Active)
       )),
-      Route[RouteProps].props(RouteProps(
+      Route(RouteProps(
         path = "/completed",
         render = _ => TodoApp(Filter.Completed)
       ))
     )
   }
+
   @react object Link extends ExternalComponent {
     case class Props(
       to: String,
       className: js.UndefOr[String]
     )
-    val component = JSLink
+    val component = JSLink.component
   }
 }

--- a/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/components/NewTodoInput.scala
+++ b/todo-mvc/src/main/scala/com/olegpy/shironeko/todomvc/components/NewTodoInput.scala
@@ -1,9 +1,12 @@
 package com.olegpy.shironeko.todomvc.components
 
 import com.olegpy.shironeko.util.shift
+import org.scalajs.dom.Event
 import slinky.core.StatelessComponent
+import slinky.core.SyntheticEvent
 import slinky.core.annotations.react
-import slinky.core.facade.{Hooks, ReactElement}
+import slinky.core.facade.Hooks
+import slinky.core.facade.ReactElement
 import slinky.web.html._
 
 
@@ -12,12 +15,16 @@ import slinky.web.html._
 
   override def render(): ReactElement = shift {
     val (text, setText) = Hooks.useState("")
+
+    def handleChange(e: SyntheticEvent[input.tag.RefType, Event]): Unit =
+      setText(e.target.value)
+
     input(
       className := "new-todo",
       placeholder := "What needs to be done?",
       autoFocus := true,
       value := text,
-      onChange := { e => setText(e.target.value) },
+      onChange := { handleChange(_) },
       onKeyPress := { e =>
         if (e.key == "Enter") {
           props.onCommit(text)


### PR DESCRIPTION
WIP to support scalajs 0.6.x and 1.x

- Update dependencies to get libraries published for the 2 targets
- Update associated code

Requires cats-effect 2.1.4 to be published in order get a fix on IOApp for the browser demo : https://github.com/typelevel/cats-effect/commit/78dd1cf954728e2389bd6d2b630934aadf8383e3
So the dependency override (master hash at the moment) could be removed.

Demo crash requires further investigation : 
```
Uncaught TypeError: Cannot read property 'Lcom_olegpy_shironeko_TaglessConnector$RenderInstance__f_algebra' of null
    at $f_Lcom_olegpy_shironeko_TaglessConnector$RenderHelpers__getAlgebra__Lcom_olegpy_shironeko_TaglessConnector$SubscribeM__O (Predef.scala:221)
    at $c_Lcom_olegpy_shironeko_todomvc_TodoApp$.subscribe__Lfs2_internal_FreeC (DirectConnector.scala:47)
    at $c_Lcom_olegpy_shironeko_DirectConnector$Container$Impl$.subscribe__Lcom_olegpy_shironeko_TaglessConnector$SubscribeM__Lfs2_internal_FreeC (DirectConnector.scala:35)
    at $c_Lcom_olegpy_shironeko_TaglessConnector$Container$underlying$.subscribe__Lcom_olegpy_shironeko_TaglessConnector$SubscribeM__Lfs2_internal_FreeC (TaglessConnector.scala:133)
    at eval (TaglessConnector.scala:96)
    at $c_sjsr_AnonFunction0.apply__O (AnonFunctions.scala:22)
    at eval (React.scala:271)
    at commitHookEffectList (react-dom.development.js:17283)
    at commitLifeCycles (react-dom.development.js:17316)
    at commitAllLifeCycles (react-dom.development.js:18736)
```


